### PR TITLE
Small Fix for Pattern Metadata

### DIFF
--- a/views/partials/patternSection.twig
+++ b/views/partials/patternSection.twig
@@ -29,7 +29,7 @@
 			<span class="sg-pattern-extra-name">HTML</span>
 			<pre>
 				<code id="sg-pattern-extra-html-container">
-					{{ partial.patternPartialCodeE | raw }}
+					{{ partial.patternPartialCode | raw }}
 				</code>
 			</pre>
 		</div>


### PR DESCRIPTION
Looks like just a simple typo! I saw the html in `#sg-pattern-extra-html-container` gone before and present after the fix, though I didn't see any changes to how the UI rendered PL with or without the "Code" option toggled. Sure this is needed for getting it going though.
