### PR TITLE
Add Package.json for NPM Install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name":             "pattern-lab/styleguidekit-twig-default",
+  "name":             "drupal-pattern-lab/styleguidekit-twig-default",
   "description":      "The default Twig-based StyleguideKit for Pattern Lab. Contains styles and mark-up for Pattern Lab's front-end.",
   "keywords":         ["twig", "pattern lab", "styleguide"],
-  "homepage":         "http://patternlab.io",
+  "homepage":         "http://drupal-pattern-lab.github.io",
   "license":          "MIT",
   "type":             "patternlab-styleguidekit",
   "authors": [
@@ -19,11 +19,10 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/pattern-lab/styleguidekit-twig-default/issues",
-    "wiki":           "http://patternlab.io/docs/",
-    "source":         "https://github.com/pattern-lab/styleguidekit-twig-default/releases"
+    "issues":         "https://github.com/drupal-pattern-lab/styleguidekit-twig-default/issues",
+    "source":         "https://github.com/drupal-pattern-lab/styleguidekit-twig-default/releases"
   },
   "require": {
-    "pattern-lab/styleguidekit-assets-default": "^3.0.0"
+    "drupal-pattern-lab/styleguidekit-assets-default": "^3.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name":             "drupal-pattern-lab/styleguidekit-twig-default",
+  "name":             "pattern-lab/styleguidekit-twig-default",
   "description":      "The default Twig-based StyleguideKit for Pattern Lab. Contains styles and mark-up for Pattern Lab's front-end.",
   "keywords":         ["twig", "pattern lab", "styleguide"],
-  "homepage":         "http://drupal-pattern-lab.github.io",
+  "homepage":         "http://patternlab.io",
   "license":          "MIT",
   "type":             "patternlab-styleguidekit",
   "authors": [
@@ -19,10 +19,11 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/drupal-pattern-lab/styleguidekit-twig-default/issues",
-    "source":         "https://github.com/drupal-pattern-lab/styleguidekit-twig-default/releases"
+    "issues":         "https://github.com/pattern-lab/styleguidekit-twig-default/issues",
+    "wiki":           "http://patternlab.io/docs/",
+    "source":         "https://github.com/pattern-lab/styleguidekit-twig-default/releases"
   },
   "require": {
-    "drupal-pattern-lab/styleguidekit-assets-default": "^3.0.0"
+    "pattern-lab/styleguidekit-assets-default": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "styleguidekit-twig-default",
+  "description": "The default Twig-based StyleguideKit for Pattern Lab. Contains styles and mark-up for Pattern Lab's front-end.",
+  "version": "3.0.2",
+  "dependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/drupal-pattern-lab/styleguidekit-twig-default.git"
+  },
+  "bugs": "https://github.com/drupal-pattern-lab/styleguidekit-twig-default/issues",
+  "authors": [
+    {
+      "name": "Dave Olsen",
+      "email": "dmolsen@gmail.com",
+      "homepage": "http://dmolsen.com",
+      "role": "Lead Developer"
+    },
+    {
+      "name": "Brad Frost",
+      "homepage": "http://bradfrostweb.com",
+      "role": "Creator"
+    },
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "role": "Developer"
+    }
+  ],
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -12,18 +12,20 @@
     {
       "name": "Dave Olsen",
       "email": "dmolsen@gmail.com",
-      "homepage": "http://dmolsen.com",
-      "role": "Lead Developer"
+      "url": "http://dmolsen.com",
     },
     {
       "name": "Brad Frost",
-      "homepage": "http://bradfrostweb.com",
+      "url": "http://bradfrostweb.com",
       "role": "Creator"
     },
     {
       "name": "Salem Ghoweri",
-      "email": "me@salemghoweri.com",
-      "role": "Developer"
+      "url": "https://github.com/sghoweri"
+    },
+    {
+      "name": "Evan Lovely",
+      "url": "https://github.com/EvanLovely"
     }
   ],
   "license": "MIT"


### PR DESCRIPTION
Adding in a package.json to allow Styleguidekit Twig templates to get installed via npm as well -- matches similar setup to what @bmuenzenmeyer has with the styleguidekit-mustache-default project.